### PR TITLE
distinguish primal and dual fails

### DIFF
--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1025,19 +1025,23 @@ class IPETEvaluation(IpetNode):
                                                                       Key.ProblemStatusCodes.MemoryLimit,
                                                                       Key.ProblemStatusCodes.Interrupted
                                                                       ]))
-        df['_fail_'] = df[Key.ProblemStatus].isin([Key.ProblemStatusCodes.FailDualBound,
+        df['_primfail_'] = df[Key.ProblemStatus].isin([
                                                     Key.ProblemStatusCodes.FailObjectiveValue,
                                                     Key.ProblemStatusCodes.FailSolInfeasible,
                                                     Key.ProblemStatusCodes.FailSolOnInfeasibleInstance,
-                                                    Key.ProblemStatusCodes.Fail
                                         ])
+        
+        df['_dualfail_'] = df[Key.ProblemStatus].isin([Key.ProblemStatusCodes.FailDualBound])
+        
+        df['_fail_'] = df['_primfail_'] | df['_dualfail_'] | (df[Key.ProblemStatus] == Key.ProblemStatusCodes.Fail)
+        
         df['_abort_'] = (df[Key.ProblemStatus] == Key.ProblemStatusCodes.FailAbort)
 
         df['_solved_'] = (~df['_limit_']) & (~df['_fail_']) & (~df['_abort_'])
 
         df['_count_'] = 1
         df['_unkn_'] = (df[Key.ProblemStatus] == Key.ProblemStatusCodes.Unknown)
-        self.countercolumns = ['_time_', '_limit_', '_fail_', '_abort_', '_solved_', '_unkn_', '_count_']
+        self.countercolumns = ['_time_', '_limit_', '_primfail_', '_dualfail_', '_fail_', '_abort_', '_solved_', '_unkn_', '_count_']
         return df
 
     def toXMLElem(self):

--- a/test/FilterDataTest.py
+++ b/test/FilterDataTest.py
@@ -58,7 +58,7 @@ class FilterDataTest(unittest.TestCase):
         # Test through the aggregated table that should contain
         # the TestGroup and therefore have exactly one row 
         #
-        expected_shape = (1, 7)
+        expected_shape = (1, 9)
         self.assertEqual(aggtable.shape, expected_shape,
                          "Expected shape {} in table, got {},n{}\n".format(expected_shape, aggtable.shape, aggtable) )         
 


### PR DESCRIPTION
add two new counter columns '_primfail_', '_dualfail_' to distinguish primal fails and dual fails. Their union remains the column _fail_, as before.