### PR TITLE
speed up filtering process considerably

### DIFF
--- a/test/EvaluationTest.py
+++ b/test/EvaluationTest.py
@@ -48,7 +48,7 @@ filtergroups = [{"filtertype":"intersection", "name":"all"},
                 {"name":"hard"}]
 
 filters = [None,
-           {"anytestrun":"any", "expression1":"Time", "expression2":"100", "operator":"ge"}]
+           {"anytestrun":"one", "expression1":"Time", "expression2":"100", "operator":"ge"}]
 
 test_out = os.path.join(DATADIR, 'check.MMM.scip-hashing.linux.x86_64.gnu.dbg.cpx.mip-dbg.heuraggr.out')
 

--- a/test/data/testevaluate.xml
+++ b/test/data/testevaluate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<Evaluation groupkey="Settings" defaultgroup="default">
+<Evaluation index="ProblemName Settings" defaultgroup="default">
 	<Column name="SolvingTime" origcolname="TotalTime_solving">
 		<Aggregation name="shmean">
 			<shiftby type="float" val="10.0"/>


### PR DESCRIPTION
Speed up filtering process by using fewer groupby operations and dropping lambda expressions. Basically, for every filter, a boolean column is computed, that represents if the row satisfies the filter condition. Grouping on this single condition column is much faster, I suppose, than on the entire data frame.

The conditional column then gets grouped by the specified index, and multiple values are aggregated using either np.all (for anytestrun=="all") or np.any (for anytestrun == "one").
The result of this aggregation is reindexed to meet the original data frame index, and appended to a list of conditional columns.

Finally, this list is concatenated and the results for each individual filter are combined with a logical and.

I get a factor 4 speedup on a typical rubberband evaluation for five test runs containing approx. 380 instances each on my laptop:
```
real    0m5.517s
user    0m5.308s
sys     0m0.500s
```

as compared to the current code on the master:

```
real    0m22.165s
user    0m21.992s
sys     0m0.468s
```

I also verified that the obtained results (by writing the tables into files) do not differ.

I guess that the 3 1/2 hours I spent here are soon amortized by the happy developers using this.