### PR TITLE
Speedup filter groups

### DIFF
--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -517,7 +517,7 @@ class IPETEvaluationColumn(IpetNode):
                         result = numpy.maximum(result, comp)
                     except:
                         logging.warning("When filling in the minimum, an error occurred for the column '{}':\n{}".format(self.getName(), self.attributesToStringDict()))
-                        result = pd.concat([result, comp], axis=1).max(axis=1)
+                        result = pd.concat([result, comp], axis = 1).max(axis = 1)
         if self.maxval is not None:
             maxval = self.parseValue(self.maxval, df_long)
             if maxval is not None:
@@ -529,7 +529,7 @@ class IPETEvaluationColumn(IpetNode):
                         result = numpy.minimum(result, comp)
                     except:
                         logging.warning("When filling in the maximum, an error occurred for the column '{}':\n{}".format(self.getName(), self.attributesToStringDict()))
-                        result = pd.concat([result, comp], axis=1).min(axis=1)
+                        result = pd.concat([result, comp], axis = 1).min(axis = 1)
         reductionindex = self.getReductionIndex(evalindexcols)
 
         #
@@ -1305,8 +1305,8 @@ class IPETEvaluation(IpetNode):
 
         # display countercolumns as integer
         counting_columns = [dfcol for dfcol in df.columns if dfcol[l].startswith("_") and dfcol[l].endswith("_")]
-        for cctup in counting_columns:
-            formatters.update({cctup:FormatFunc("%d").beautify})
+        # for cctup in counting_columns:
+        #   formatters.update({cctup:FormatFunc("%d").beautify})
 
         for comptuple in comptuples:
             formatters.update({comptuple:FormatFunc(self.comparecolformat).beautify})

--- a/ipet/evaluation/IPETEvalTable.py
+++ b/ipet/evaluation/IPETEvalTable.py
@@ -1305,8 +1305,8 @@ class IPETEvaluation(IpetNode):
 
         # display countercolumns as integer
         counting_columns = [dfcol for dfcol in df.columns if dfcol[l].startswith("_") and dfcol[l].endswith("_")]
-        # for cctup in counting_columns:
-        #   formatters.update({cctup:FormatFunc("%d").beautify})
+        for cctup in counting_columns:
+            formatters.update({cctup:FormatFunc("%d").beautify})
 
         for comptuple in comptuples:
             formatters.update({comptuple:FormatFunc(self.comparecolformat).beautify})
@@ -1750,22 +1750,25 @@ class IPETEvaluation(IpetNode):
         for idx, f in enumerate(activefilters):
             if idx > 0:
                 previous_f = activefilters[idx - 1]
-
-                #
-                # try to skip the computation of the filter column if an equal
-                # filter already has a stored result
-                #
                 stored_result = previous_f.getStoredResult(df)
 
-                if f.equals(previous_f) and stored_result is not None:
-                    logging.debug("Reusing previously stored result for filter {}".format(f.getName()))
-                    fcol = stored_result
-                else:
-                    fcol = f.applyFilter(df, self.getRowIndex())
-                #
-                # store the result (either by applying the filter, or by copying)
-                #
-                f.storeResult(df, fcol)
+            else:
+                previous_f = None
+                stored_result = None
+
+            #
+            # try to skip the computation of the filter column if an equal
+            # filter already has a stored result
+            #
+            if f.equals(previous_f) and stored_result is not None:
+                logging.debug("Reusing previously stored result for filter {}".format(f.getName()))
+                fcol = stored_result
+            else:
+                fcol = f.applyFilter(df, self.getRowIndex())
+            #
+            # store the result (either by applying the filter, or by copying)
+            #
+            f.storeResult(df, fcol)
 
 
 

--- a/ipet/evaluation/IPETFilter.py
+++ b/ipet/evaluation/IPETFilter.py
@@ -509,6 +509,8 @@ class IPETFilterGroup(IpetNode):
     # global data frame and index that are reused for several filter groups
     _glbdf_ = None
     _glbindex_ = None
+
+    # intersection row index which can be shared across all filter groups of type "intersection"
     _glbinterrows_ = None
 
 
@@ -583,6 +585,11 @@ class IPETFilterGroup(IpetNode):
     @staticmethod
     def computeIntersectionRows(df : pd.DataFrame, index):
         """Compute intersection rows of a given data frame and index
+
+        Intersection rows denote a boolean index to define the subset of rows of the input frame
+        considered as "intersection" for filter groups that have the "intersection" type (which is the default).
+        The intersection row computation is slow and is reused across all
+        filter groups with the intersection type.
         """
 
         logging.info("Computing rows for intersection groups")

--- a/ipet/evaluation/IPETFilter.py
+++ b/ipet/evaluation/IPETFilter.py
@@ -538,9 +538,9 @@ class IPETFilterGroup(IpetNode):
             instancecount = groups.apply(len).max()
             interrows = groups.apply(lambda x:len(x) == instancecount)
 
-            index_series = [interrows.reindex(dfindex)]
+            intersection_index = interrows.reindex(dfindex)
         elif self.filtertype == "union":
-            index_series = []
+            intersection_index = None
 
 
         renaming = {i:"{}_filter".format(i) for i in index}
@@ -562,13 +562,17 @@ class IPETFilterGroup(IpetNode):
             # reshape the column to match the original data frame rows
             #
             fcol = fcol_index.reindex(index = dfindex, axis = 0)
-            index_series.append(fcol)
+
+            if intersection_index is not None:
+                intersection_index = intersection_index & fcol
+            else:
+                intersection_index = fcol
 
         #
         # aggregate the single, elementwise filters into a single intersection
         # series with one row per index element
         #
-        intersection_index = pd.concat(index_series, axis = 1).apply(np.all, axis = 1)
+        # intersection_index = pd.concat(index_series, axis = 1).apply(np.all, axis = 1)
 
         lvalues = intersection_index.values
 

--- a/ipet/parsing/Solver.py
+++ b/ipet/parsing/Solver.py
@@ -779,7 +779,7 @@ class XpressSolver(Solver):
                        "STOPPING - MAXTIME limit reached" : Key.SolverStatusCodes.TimeLimit,
                        #                       "" : Key.SolverStatusCodes.MemoryLimit,
                        #                       "" : Key.SolverStatusCodes.NodeLimit,
-                      r" \*\*\* Search unfinished \*\*\*" : Key.SolverStatusCodes.Interrupted,
+                       # r" \*\*\* Search unfinished \*\*\*" : Key.SolverStatusCodes.Interrupted,
                       r"\?66 Error: Unable to open file" : Key.SolverStatusCodes.Readerror
                        }
 

--- a/ipet/validation/Validation.py
+++ b/ipet/validation/Validation.py
@@ -83,7 +83,7 @@ class Validation:
             for name, objsense, primbound, dualbound, status in c:
 
                 if name in soludict:
-                    logging.warn("Warning: Duplicate name {} with different data in data base".format(name))
+                    logging.warning("Warning: Duplicate name {} with different data in data base".format(name))
 
                 infotuple = [None, None]
                 if status == DataBaseMarkers.OPT:
@@ -248,7 +248,7 @@ class Validation:
         elif not pd.isnull(x.get(Key.ObjectiveSense, None)):
             return x.get(Key.ObjectiveSense)
         else:
-            logging.warn("No objective sense for {}, assuming minimization".format(problemname))
+            logging.warning("No objective sense for {}, assuming minimization".format(problemname))
             return ObjectiveSenseCode.MINIMIZE
 
     def validateSeries(self, x : pd.Series) -> str:

--- a/test/FilterMethodsTest.py
+++ b/test/FilterMethodsTest.py
@@ -1,0 +1,83 @@
+'''
+Created on 21.03.2018
+
+@author: gregor
+'''
+import unittest
+from ipet.evaluation import IPETFilter
+from _ast import Attribute
+from ipet.evaluation.IPETFilter import IPETValue
+
+
+class FilterMethodsTest(unittest.TestCase):
+
+    def testFilterComparison(self):
+
+        # test if different operators are correctly distinguished
+        operatorlist = ["le", "ge", "lt", "gt", "eq", "neq"]
+        for operator1 in operatorlist:
+            for operator2 in operatorlist:
+                f1 = IPETFilter("A", "B", operator1)
+                f2 = IPETFilter("A", "B", operator2)
+                eq = f1.equals(f2)
+                self.assertEqual(eq, operator1 == operator2, "Bla")
+
+    def testAnyAll(self):
+        # test if filters that have all attributes equal except for the anytestrun attribute are distinguished
+        commonattributes = dict(expression1 = "A", expression2 = "B", operator = "eq", active = True, datakey = "C")
+        possiblevalues = ["one", "all"]
+
+        for any1 in possiblevalues:
+            for any2 in possiblevalues:
+                f1 = IPETFilter(anytestrun = any1, **commonattributes)
+                f2 = IPETFilter(anytestrun = any2, **commonattributes)
+
+                eq = f1.equals(f2)
+                self.assertEqual(eq, any1 == any2, "Bla")
+
+    def testListOperators(self):
+        attributes = IPETFilter.listoperators
+        commonattributes = dict(datakey = "A", anytestrun = "all")
+        for op1 in attributes:
+            for op2 in attributes:
+                f1 = IPETFilter(operator = op1, **commonattributes)
+                f2 = IPETFilter(operator = op2, **commonattributes)
+
+                eq = f1.equals(f2)
+                self.assertEqual(eq, op1 == op2, "Bla")
+
+
+    def testValueLists(self):
+
+        valuelist1 = [
+            [IPETValue("A"), IPETValue("B"), IPETValue("C")],
+            [IPETValue("A"), IPETValue("B"), IPETValue("C")],
+            [IPETValue("A"), ]
+            ]
+        valuelist2 = [
+            [IPETValue("A"), IPETValue("B"), IPETValue("C")],
+            [IPETValue("A"), IPETValue("B"), IPETValue("C")],
+            [IPETValue("A"), IPETValue("B"), IPETValue("C")]
+            ]
+
+        operators1 = IPETFilter.valueoperators + IPETFilter.valueoperators[:1]
+        operator2 = "keep"
+
+        for op, v1list, v2list in zip(operators1, valuelist1, valuelist2):
+            f1 = IPETFilter(datakey = "ABC", operator = op)
+            f2 = IPETFilter(datakey = "ABC", operator = operator2)
+
+            for v1 in v1list:
+                f1.addChild(v1)
+            for v2 in v2list:
+                f2.addChild(v2)
+
+            eq = f1.equals(f2)
+            shouldbeequal = (op == operator2) and len(v1list) == len(v2list)
+
+            self.assertEqual(eq, shouldbeequal, "bla")
+
+
+if __name__ == "__main__":
+    # import sys;sys.argv = ['', 'Test.testFilterComparison']
+    unittest.main()

--- a/test/FilterMethodsTest.py
+++ b/test/FilterMethodsTest.py
@@ -11,6 +11,9 @@ from ipet.evaluation.IPETFilter import IPETValue
 
 class FilterMethodsTest(unittest.TestCase):
 
+    def assertionMessage(self, f1, f2):
+        return "Filter comparison fails for the filters {} and {}".format(f1.getName(), f2.getName())
+
     def testFilterComparison(self):
 
         # test if different operators are correctly distinguished
@@ -20,7 +23,8 @@ class FilterMethodsTest(unittest.TestCase):
                 f1 = IPETFilter("A", "B", operator1)
                 f2 = IPETFilter("A", "B", operator2)
                 eq = f1.equals(f2)
-                self.assertEqual(eq, operator1 == operator2, "Bla")
+                self.assertEqual(eq, operator1 == operator2,
+                                 self.assertionMessage(f1, f2))
 
     def testAnyAll(self):
         # test if filters that have all attributes equal except for the anytestrun attribute are distinguished
@@ -33,7 +37,7 @@ class FilterMethodsTest(unittest.TestCase):
                 f2 = IPETFilter(anytestrun = any2, **commonattributes)
 
                 eq = f1.equals(f2)
-                self.assertEqual(eq, any1 == any2, "Bla")
+                self.assertEqual(eq, any1 == any2, self.assertionMessage(f1, f2))
 
     def testListOperators(self):
         attributes = IPETFilter.listoperators
@@ -44,7 +48,7 @@ class FilterMethodsTest(unittest.TestCase):
                 f2 = IPETFilter(operator = op2, **commonattributes)
 
                 eq = f1.equals(f2)
-                self.assertEqual(eq, op1 == op2, "Bla")
+                self.assertEqual(eq, op1 == op2, self.assertionMessage(f1, f2))
 
 
     def testValueLists(self):
@@ -75,7 +79,7 @@ class FilterMethodsTest(unittest.TestCase):
             eq = f1.equals(f2)
             shouldbeequal = (op == operator2) and len(v1list) == len(v2list)
 
-            self.assertEqual(eq, shouldbeequal, "bla")
+            self.assertEqual(eq, shouldbeequal, self.assertionMessage(f1, f2))
 
 
 if __name__ == "__main__":

--- a/test/SolverTest.py
+++ b/test/SolverTest.py
@@ -18,7 +18,7 @@ PRECISE = 0
 ALMOST = 1
 
 class SolverTest(unittest.TestCase):
-    
+
     fileinfo = {
                 "cbc-app1-2" : [ {
                     Key.Solver: "CBC",
@@ -26,7 +26,7 @@ class SolverTest(unittest.TestCase):
                     Key.SolverStatus: Key.SolverStatusCodes.TimeLimit }, {
                     Key.SolvingTime: 7132.49,
                     Key.PrimalBound: None,
-                    Key.DualBound: -96.111} ],
+                    Key.DualBound:-96.111} ],
                 "cbc-ash608gpia-3col" : [ {
                     Key.Solver: "CBC",
                     Key.Version: "2.9.8",
@@ -39,8 +39,8 @@ class SolverTest(unittest.TestCase):
                     Key.Version: "2.9.8",
                     Key.SolverStatus: Key.SolverStatusCodes.TimeLimit }, {
                     Key.SolvingTime: 7194.79,
-                    Key.PrimalBound: -104286.921,
-                    Key.DualBound: -111273.306} ],
+                    Key.PrimalBound:-104286.921,
+                    Key.DualBound:-111273.306} ],
                 "cbc-dfn-gwin-UUM" : [ {
                     Key.Solver: "CBC",
                     Key.Version: "2.9.8",
@@ -60,20 +60,20 @@ class SolverTest(unittest.TestCase):
                     Key.Version: "2.9.8",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
                     Key.SolvingTime: 4511.76,
-                    Key.PrimalBound: -5,
-                    Key.DualBound: -5} ],
+                    Key.PrimalBound:-5,
+                    Key.DualBound:-5} ],
                 "cplex-app1-2" : [ {
                     Key.Solver: "CPLEX",
                     Key.Version: "12.7.1.0",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -41,
-                    Key.DualBound: -41} ],
+                    Key.PrimalBound:-41,
+                    Key.DualBound:-41} ],
                 "cplex-bab5" : [ {
                     Key.Solver: "CPLEX",
                     Key.Version: "12.7.1.0",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -106411.84,
-                    Key.DualBound: -106411.84} ],
+                    Key.PrimalBound:-106411.84,
+                    Key.DualBound:-106411.84} ],
                 "cplex-dfn-gwin-UUM" : [ {
                     Key.Solver: "CPLEX",
                     Key.Version: "12.7.1.0",
@@ -90,20 +90,20 @@ class SolverTest(unittest.TestCase):
                     Key.Solver: "CPLEX",
                     Key.Version: "12.7.1.0",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -5,
-                    Key.DualBound: -5} ],
+                    Key.PrimalBound:-5,
+                    Key.DualBound:-5} ],
                 "gurobi-app1-2" : [ {
                     Key.Solver: "GUROBI",
                     Key.Version: "7.0.0",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -41 ,
-                    Key.DualBound: -41} ],
+                    Key.PrimalBound:-41 ,
+                    Key.DualBound:-41} ],
                 "gurobi-bab5" : [ {
                     Key.Solver: "GUROBI",
                     Key.Version: "7.0.0",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -106411.84 ,
-                    Key.DualBound: -106411.84} ],
+                    Key.PrimalBound:-106411.84 ,
+                    Key.DualBound:-106411.84} ],
                 "gurobi-dfn-gwin-UUM" : [ {
                     Key.Solver: "GUROBI",
                     Key.Version: "7.0.0",
@@ -120,19 +120,19 @@ class SolverTest(unittest.TestCase):
                     Key.Solver: "GUROBI",
                     Key.Version: "7.0.0",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -5 ,
-                    Key.DualBound: -5} ],
+                    Key.PrimalBound:-5 ,
+                    Key.DualBound:-5} ],
                 "xpress-app1-2" : [ {
                     Key.Solver: "XPRESS",
                     Key.Version: "30.01.03",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -41,
-                    Key.DualBound: -41} ],
+                    Key.PrimalBound:-41,
+                    Key.DualBound:-41} ],
                 "xpress-bab5" : [ {
                     Key.Solver: "XPRESS",
                     Key.Version: "30.01.03",
                     Key.SolverStatus: Key.SolverStatusCodes.TimeLimit }, {
-                    Key.PrimalBound: -106411.84,
+                    Key.PrimalBound:-106411.84,
                     Key.DualBound:-106701.8161} ],
                 "xpress-dfn-gwin-UUM" : [ {
                     Key.Solver: "XPRESS",
@@ -150,8 +150,8 @@ class SolverTest(unittest.TestCase):
                     Key.Solver: "XPRESS",
                     Key.Version: "30.01.03",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: -5 ,
-                    Key.DualBound: -5} ],
+                    Key.PrimalBound:-5 ,
+                    Key.DualBound:-5} ],
                 "mipcl-app1-2" : [ {
                     Key.Solver: "MIPCL",
                     Key.Version: "1.3.1",
@@ -185,32 +185,32 @@ class SolverTest(unittest.TestCase):
                 "scip-infeasible" : [ {
                     Key.Solver: "SCIP",
                     Key.SolverStatus: Key.SolverStatusCodes.Infeasible }, {
-                    Key.PrimalBound: +1.00000000000000e+20,
-                    Key.DualBound: +1.00000000000000e+20} ],
+                    Key.PrimalBound:+1.00000000000000e+20,
+                    Key.DualBound:+1.00000000000000e+20} ],
                 "scip-memorylimit" : [ {
                     Key.Solver: "SCIP",
                     Key.SolverStatus: Key.SolverStatusCodes.MemoryLimit }, {
-                    Key.PrimalBound: +1.49321500000000e+06,
-                    Key.DualBound: +1.49059347656250e+06} ],
+                    Key.PrimalBound:+1.49321500000000e+06,
+                    Key.DualBound:+1.49059347656250e+06} ],
                 "scip-optimal" : [ {
                     Key.Solver: "SCIP",
                     Key.SolverStatus: Key.SolverStatusCodes.Optimal }, {
-                    Key.PrimalBound: +3.36000000000000e+03,
-                    Key.DualBound: +3.36000000000000e+03} ],
+                    Key.PrimalBound:+3.36000000000000e+03,
+                    Key.DualBound:+3.36000000000000e+03} ],
                 "scip-timelimit" : [ {
                     Key.Solver: "SCIP",
                     Key.SolverStatus: Key.SolverStatusCodes.TimeLimit }, {
-                    Key.PrimalBound: +1.16800000000000e+03,
-                    Key.DualBound: +1.13970859166290e+03} ],
+                    Key.PrimalBound:+1.16800000000000e+03,
+                    Key.DualBound:+1.13970859166290e+03} ],
                 "scip-crashed" : [ {
                     Key.Solver: "SCIP",
                     Key.SolverStatus: Key.SolverStatusCodes.Crashed }, {
                     Key.PrimalBound: None,
                     Key.DualBound: None} ]
                 }
-    
+
     solvers = []
-    
+
     def setUp(self):
         self.solvers.append([SCIPSolver(), "SCIP"])
         self.solvers.append([GurobiSolver(), "GUROBI"])
@@ -238,7 +238,7 @@ class SolverTest(unittest.TestCase):
 
     def assertPrecise(self, filename, key):
         refvalue = self.fileinfo.get(filename)[PRECISE].get(key)
-        self.assertEqual(refvalue, self.activeSolver.getData(key))
+        self.assertEqual(refvalue, self.activeSolver.getData(key), "Wrong key value {}:{} parsed by solver {} from file {}".format(key, self.activeSolver.getData(key), self.activeSolver.getName(), filename))
 
     def assertAlmost(self, filename, key):
         refbound = self.fileinfo.get(filename)[ALMOST].get(key)
@@ -263,12 +263,12 @@ class SolverTest(unittest.TestCase):
                     if solver.recognizeOutput(line):
                         self.activeSolver = solver
                         return
-                
+
     def getFileName(self, basename):
         return os.path.join(DATADIR, "{}.{}".format(basename, "out"))
 
 if __name__ == "__main__":
     unittest.main()
-    
-    
-    
+
+
+


### PR DESCRIPTION
speed up IPET evaluation considerably through

- grouping all active filters and reusing
  already computed results from equal
  filters across filter groups
- reusing the same set of intersection rows
  across all filter groups
- replacing some apply operations by bitwise ands
