### PR TITLE
restructure logger for use with other modules

### DIFF
--- a/ipet/Experiment.py
+++ b/ipet/Experiment.py
@@ -13,7 +13,6 @@ from ipet import misc, Key
 from .TestRun import TestRun
 from ipet.concepts.Manager import Manager
 from ipet.misc.integrals import calcIntegralValue, getProcessPlotData
-from ipet.parsing import ErrorFileReader, BestSolInfeasibleReader, ObjlimitReader, ObjsenseReader
 from ipet.parsing.ReaderManager import ReaderManager
 from pandas import Panel
 
@@ -22,8 +21,9 @@ import pickle
 import os
 import sys
 import logging
-from ipet.Key import SolverStatusCodes
 from ipet.validation import Validation
+
+logger = logging.getLogger(__name__)
 
 class Experiment:
     """
@@ -172,8 +172,8 @@ class Experiment:
         try:
             self.externaldata = pd.read_table(filename, sep = " *", engine = 'python', header = 1, skipinitialspace = True)
             self.updateDatakeys()
-            logging.debug("Experiment read external data file %s" % filename)
-            logging.debug("%s" % self.externaldata.head(5))
+            logger.debug("Experiment read external data file %s" % filename)
+            logger.debug("%s" % self.externaldata.head(5))
         except:
             raise ValueError("Error reading file name %s" % filename)
 
@@ -265,18 +265,18 @@ class Experiment:
                 if processplotdata:
                     try:
                         testrun.addDataById(Key.PrimalIntegral, calcIntegralValue(processplotdata), problemid)
-                        logging.debug("Computed primal integral %.1f for problem %s, data %s" % (testrun.getProblemDataById(problemid, 'PrimalIntegral'), problemid, repr(processplotdata)))
+                        logger.debug("Computed primal integral %.1f for problem %s, data %s" % (testrun.getProblemDataById(problemid, 'PrimalIntegral'), problemid, repr(processplotdata)))
                     except AssertionError:
-                        logging.error("Error for primal bound on problem %s, list: %s" % (problemid, processplotdata))
+                        logger.error("Error for primal bound on problem %s, list: %s" % (problemid, processplotdata))
 
                 processplotdata = getProcessPlotData(testrun, problemid, reference = self.validation.getReferenceDb(problemname), **dualargs)
                 # check for well defined data (may not exist sometimes)
                 if processplotdata:
                     try:
                         testrun.addDataById(Key.DualIntegral, calcIntegralValue(processplotdata, pwlinear = True), problemid)
-                        logging.debug("Computed dual integral %.1f for problem %s, data %s" % (testrun.getProblemDataById(problemid, 'DualIntegral'), problemid, repr(processplotdata)))
+                        logger.debug("Computed dual integral %.1f for problem %s, data %s" % (testrun.getProblemDataById(problemid, 'DualIntegral'), problemid, repr(processplotdata)))
                     except AssertionError:
-                        logging.error("Error for dual bound on problem %s, list: %s " % (problemid, processplotdata))
+                        logger.error("Error for dual bound on problem %s, list: %s " % (problemid, processplotdata))
 
 
 

--- a/ipet/TestRun.py
+++ b/ipet/TestRun.py
@@ -12,14 +12,14 @@ please refer to README.md for how to cite IPET.
 from ipet import Key
 from ipet import misc
 from pandas import DataFrame, notnull
-from ipet.parsing import StatisticReader
 import os, sys
 import logging
-import pandas as pd
 from ipet.Key import CONTEXT_LOGFILE
 from ipet.validation import Validation
 # from lib2to3.fixes.fix_input import context
 # from matplotlib.tests import test_lines
+
+logger = logging.getLogger(__name__)
 
 try:
     import pickle as pickle
@@ -132,7 +132,7 @@ class TestRun:
         readers can use this method to add data, either as a single datakey, or as list,
         where in the latter case it is required that datakeys and data are both lists of the same length
         """
-        logging.debug("TestRun %s receives data Datakey %s, %s" % (self.getName(), repr(datakey), repr(data)))
+        logger.debug("TestRun %s receives data Datakey %s, %s" % (self.getName(), repr(datakey), repr(data)))
 
         if type(datakey) is list and type(data) is list:
             for key, datum in zip(datakey, data):
@@ -157,7 +157,7 @@ class TestRun:
         after data was added, the method getProblemDataById() can be used for access if a problemid was given
         """
         # check for the right dictionary to store the data
-        logging.debug("TestRun %s receives data Datakey %s, %s to problem %s" % (self.getName(), repr(datakeys), repr(data), problemid))
+        logger.debug("TestRun %s receives data Datakey %s, %s to problem %s" % (self.getName(), repr(datakeys), repr(data), problemid))
 
         if type(datakeys) is list and type(data) is list:
             for key, datum in zip(datakeys, data):

--- a/ipet/concepts/IPETNode.py
+++ b/ipet/concepts/IPETNode.py
@@ -11,6 +11,9 @@ please refer to README.md for how to cite IPET.
 """
 from ipet.concepts.Editable import Editable, EditableAttributeError
 import logging
+
+logger = logging.getLogger(__name__)
+
 class IpetNode(Editable):
     """
     A Node is an interface to an XML-like ancestor-structure
@@ -31,7 +34,7 @@ class IpetNode(Editable):
 
         for d, message in self.deprecatedattrdir.items():
             if d in kw:
-                logging.warning("Warning : The attribute '{0}' is deprecated and will be ignored; {1}. ".format(d, message))
+                logger.warning("Warning : The attribute '{0}' is deprecated and will be ignored; {1}. ".format(d, message))
 
     def addChild(self, child):
         """

--- a/ipet/evaluation/IPETFilter.py
+++ b/ipet/evaluation/IPETFilter.py
@@ -16,6 +16,8 @@ import logging
 import pandas as pd
 from ipet.evaluation import TestSets
 
+logger = logging.getLogger(__name__)
+
 class IPETValue(IpetNode):
     nodetag = "Value"
 
@@ -92,7 +94,7 @@ class IPETComparison:
         try:
             return method(x, y)
         except TypeError as t:
-            logging.error("Got type error %s comparing elements x:%s and y:%s" % (t, x, y))
+            logger.error("Got type error %s comparing elements x:%s and y:%s" % (t, x, y))
             return 0
 
     def method_le(self, x, y):
@@ -241,10 +243,10 @@ class IPETFilter(IpetNode):
         for i in self.valueset:
 
             if i in TestSets.getTestSets():
-                logging.debug("Adding test set {} to value set".format(i))
+                logger.debug("Adding test set {} to value set".format(i))
                 updateset = updateset.union(set(TestSets.getTestSetByName(i)))
         self.valueset = self.valueset.union(updateset)
-        logging.debug("Complete value set of filter {}:\n{}".format(self.getName(), self.valueset))
+        logger.debug("Complete value set of filter {}:\n{}".format(self.getName(), self.valueset))
 
         self._updatevalueset = False
 
@@ -254,7 +256,7 @@ class IPETFilter(IpetNode):
 
         self.checkAndUpdateValueSet(dtype)
         contained = df.isin(self.valueset)
-        logging.debug("Contained: {}\nData: {}".format(contained, df))
+        logger.debug("Contained: {}\nData: {}".format(contained, df))
         if self.operator == "keep":
             return contained
         else:
@@ -592,7 +594,7 @@ class IPETFilterGroup(IpetNode):
         filter groups with the intersection type.
         """
 
-        logging.info("Computing rows for intersection groups")
+        logger.info("Computing rows for intersection groups")
 
         dfindex = df.set_index(index).index
 

--- a/ipet/parsing/ReaderManager.py
+++ b/ipet/parsing/ReaderManager.py
@@ -21,7 +21,7 @@ from .StatisticReader_CustomReader import CustomReader
 from .TraceFileReader import TraceFileReader
 from ipet.concepts.Manager import Manager
 from ipet.concepts.IPETNode import IpetNode
-from ipet.parsing.Solver import Solver, SCIPSolver, CbcSolver, XpressSolver, GurobiSolver, \
+from ipet.parsing.Solver import SCIPSolver, CbcSolver, XpressSolver, GurobiSolver, \
     CplexSolver, FiberSCIPSolver, MatlabSolver, MosekSolver, MipclSolver, NuoptSolver, SasSolver
 from ipet.misc import misc
 # CbcSolver, CouenneSolver, \
@@ -29,6 +29,8 @@ from ipet.misc import misc
 from ipet import Key
 from ipet.IPETError import IPETInconsistencyError
 from ipet.Key import CONTEXT_ERRFILE, CONTEXT_LOGFILE
+
+logger = logging.getLogger(__name__)
 
 class ReaderManager(Manager, IpetNode):
     """
@@ -82,7 +84,7 @@ class ReaderManager(Manager, IpetNode):
 
     def addSolver(self, solver):
         self.solvers.append(solver)
-        logging.debug("Added a solver: {}".format(solver.getName()))
+        logger.debug("Added a solver: {}".format(solver.getName()))
 
     def getName(self):
         """
@@ -124,7 +126,7 @@ class ReaderManager(Manager, IpetNode):
         """
         changes the testrun for reading to the new testrun
         """
-        logging.debug("Setting testrun to %s" % testrun.getName())
+        logger.debug("Setting testrun to %s" % testrun.getName())
         self.testrun = testrun
         for reader in self.getManageables():
             reader.setTestRun(testrun)
@@ -300,9 +302,9 @@ class ReaderManager(Manager, IpetNode):
                     try:
                         self.updateProblemName(line, context, readers)
                     except IPETInconsistencyError as e:
-                        logging.warning(e.msg)
+                        logger.warning(e.msg)
                         if context == CONTEXT_ERRFILE:
-                            logging.warning("Skipping parsing of the rest of the .err file.")
+                            logger.warning("Skipping parsing of the rest of the .err file.")
                             break
 
                 if self.endOfProblemReached(line[1]):

--- a/ipet/parsing/Solver.py
+++ b/ipet/parsing/Solver.py
@@ -8,6 +8,8 @@ from builtins import int, str
 import logging
 from numpy import char
 
+logger = logging.getLogger(__name__)
+
 class Solver():
     """ The solver-class acts as Reader for solver-specific data.
 
@@ -219,7 +221,7 @@ class Solver():
         history = self.data.setdefault(key, [])
         # only append newly found bounds
 
-        logging.debug("pointinTime %s, bound %s, key %s \n" % (timestr, boundstr, key))
+        logger.debug("pointinTime %s, bound %s, key %s \n" % (timestr, boundstr, key))
         if history == [] or history[-1][1] != bound:
             if(key == Key.PrimalBoundHistory):
                 history.append((time, bound))

--- a/ipet/parsing/StatisticReader.py
+++ b/ipet/parsing/StatisticReader.py
@@ -16,6 +16,8 @@ from ipet.misc import misc
 from ipet import Key
 import logging
 
+logger = logging.getLogger(__name__)
+
 class StatisticReader(IpetNode):
     """
     base class for all statistic readers - readers should always inherit from this base class for minimal implementation
@@ -115,7 +117,7 @@ class StatisticReader(IpetNode):
         self.extractStatistic(line)
 
     def addData(self, datakey, data):
-        logging.debug("Reader %s adds data" % (self.getName()))
+        logger.debug("Reader %s adds data" % (self.getName()))
         self.testrun.addData(datakey, data)
 
     def turnIntoFloat(self, astring):

--- a/ipet/parsing/StatisticReader_CustomReader.py
+++ b/ipet/parsing/StatisticReader_CustomReader.py
@@ -16,6 +16,8 @@ import logging
 from ipet import misc
 from ipet.concepts.IPETNode import IpetNode
 
+logger = logging.getLogger(__name__)
+
 class CustomReader(StatisticReader):
     """
     Reader to be initialised interactively through IPET or from an interactive python shell
@@ -140,7 +142,7 @@ class CustomReader(StatisticReader):
                         self.addData(self.datakey, data)
 
             except:
-                logging.debug("Reader %s could not retrieve data at index %d from matching line '%s'", self.getName(), self.index, line)
+                logger.debug("Reader %s could not retrieve data at index %d from matching line '%s'", self.getName(), self.index, line)
                 pass
 
 
@@ -154,7 +156,7 @@ class CustomReader(StatisticReader):
             self.datatypemethod = getattr(builtins, sometype)
             self.datatype = sometype
         except:
-            logging.debug("Error: Could not recognize data type %s, using float" % sometype)
+            logger.debug("Error: Could not recognize data type %s, using float" % sometype)
             self.datatypemethod = float
             self.datatype = 'float'
     def set_datatype(self, datatype):

--- a/ipet/parsing/TraceFileReader.py
+++ b/ipet/parsing/TraceFileReader.py
@@ -14,6 +14,8 @@ from ipet.misc import FLOAT_INFINITY
 from ipet import Key
 import logging
 
+logger = logging.getLogger(__name__)
+
 class TraceFileReader(StatisticReader):
     """
     classdocs
@@ -51,7 +53,7 @@ class TraceFileReader(StatisticReader):
             probname = splitline[0]
             datavalues = list(map(self.prepareData, splitline[1:]))
 
-            logging.debug("Trace File Reader adds data for problem %s", probname)
+            logger.debug("Trace File Reader adds data for problem %s", probname)
             self.testrun.addDataByName(self.datakeys, datavalues, probname)
 
 

--- a/ipet/validation/Validation.py
+++ b/ipet/validation/Validation.py
@@ -11,7 +11,8 @@ from ipet.misc import isInfinite as isInf
 import numpy as np
 import logging
 import sqlite3
-from pandas.core.series import Series
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_RELTOL = 1e-4
 DEFAULT_FEASTOL = 1e-6
@@ -106,7 +107,7 @@ class Validation:
             for name, objsense, primbound, dualbound, status in c:
 
                 if name in soludict:
-                    logging.warning("Warning: Duplicate name {} with different data in data base".format(name))
+                    logger.warning("Warning: Duplicate name {} with different data in data base".format(name))
 
                 infotuple = [None, None]
                 if status == DataBaseMarkers.OPT:
@@ -274,7 +275,7 @@ class Validation:
         elif not pd.isnull(x.get(Key.ObjectiveSense, None)):
             return x.get(Key.ObjectiveSense)
         else:
-            logging.warning("No objective sense for {}, assuming minimization".format(problemname))
+            logger.warning("No objective sense for {}, assuming minimization".format(problemname))
             return ObjectiveSenseCode.MINIMIZE
 
     def validateSeries(self, x : pd.Series) -> str:
@@ -505,7 +506,7 @@ class Validation:
         d : DataFrame
             joined data from an experiment.
         """
-        logging.info("Validating with a (gap) tolerance of {} and a feasibility tolerance of {}.".format(self.tol, self.feastol))
+        logger.info("Validating with a (gap) tolerance of {} and a feasibility tolerance of {}.".format(self.tol, self.feastol))
 
         #
         # 1) collect inconsistencies

--- a/scripts/ipet-evaluate
+++ b/scripts/ipet-evaluate
@@ -134,7 +134,7 @@ if __name__ == '__main__':
 
     # if globals().get("help") is not None:
     logger = logging.getLogger()
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter('%(asctime)s - %(levelname)7s - %(name)s - %(message)s')
     ch = logging.StreamHandler(sys.stdout)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
@@ -154,7 +154,7 @@ if __name__ == '__main__':
                 try:
                     _ = IPETEvaluation.fromXMLFile(_file)
                     evalfile = _file
-                    logging.info("No eval-file specified, using evaluation %s from current directory" % evalfile)
+                    logger.info("No eval-file specified, using evaluation %s from current directory" % evalfile)
                     break
                 except Exception as e:
                     print(e)
@@ -166,9 +166,9 @@ if __name__ == '__main__':
                 _ = IPETEvaluation.fromXMLFile(evalfile)
             except Exception as e:
                 print(e)
-                logging.info("No eval-file specified, and standard evaluation %s could not be loaded -- Stopping" % evalfile)
+                logger.info("No eval-file specified, and standard evaluation %s could not be loaded -- Stopping" % evalfile)
                 sys.exit(0)
-            logging.info("No eval-file specified, using standard evaluation %s" % evalfile)
+            logger.info("No eval-file specified, using standard evaluation %s" % evalfile)
     else:
         evalfile = arguments.evalfile
 
@@ -186,7 +186,7 @@ if __name__ == '__main__':
             if _file.endswith(".solu"):
                 validate = _file
                 theeval.set_validate(validate)
-                logging.info("No validation information specified, using '{}' from working directory".format(validate))
+                logger.info("No validation information specified, using '{}' from working directory".format(validate))
                 break
     elif arguments.validate:
         theeval.set_validate(arguments.validate)
@@ -200,7 +200,7 @@ if __name__ == '__main__':
         experiment.addOutputFile(trfile)
 
     if arguments.recollect is not False:
-        logging.info("Recollecting data")
+        logger.info("Recollecting data")
         experiment.collectData()
         # TODO What was it about the validation?
         # if arguments.recheckTestrun:
@@ -229,20 +229,20 @@ if __name__ == '__main__':
 
     if arguments.externaldata is not None:
         experiment.addExternalDataFile(arguments.externaldata)
-        logging.info("Added external data file %s" % arguments.externaldata)
+        logger.info("Added external data file %s" % arguments.externaldata)
     else:
-        logging.info("No external data file")
+        logger.info("No external data file")
         experiment.externaldata = None
 
     if arguments.compformatstring is not None:
         theeval.setCompareColFormat(arguments.compformatstring)
 
     if arguments.keysearch is not None:
-        logging.info("Starting key enumeration")
+        logger.info("Starting key enumeration")
         for key in experiment.getDatakeys():
             if re.search(arguments.keysearch, key):
-                logging.info("    " + key)
-        logging.info("End key enumeration")
+                logger.info("    " + key)
+        logger.info("End key enumeration")
         exit(0)
 
     if arguments.showapp:
@@ -290,18 +290,18 @@ if __name__ == '__main__':
             instancewisename = "%s/%s%s" % (path, prefixstr, fg.name)
 
             theeval.streamDataFrame(theeval.getInstanceGroupData(fg), instancewisename, extension)
-            logging.info("Instance-wise data written to %s.%s" % (instancewisename, extension))
+            logger.info("Instance-wise data written to %s.%s" % (instancewisename, extension))
             aggname = instancewisename + "_agg"
             theeval.streamDataFrame(theeval.getAggregatedGroupData(fg), aggname, extension)
-            logging.info("aggregated data written to %s.%s" % (aggname, extension))
+            logger.info("aggregated data written to %s.%s" % (aggname, extension))
 
         filename = "%s/%s" % (path, "_".join((prefixstr, "inst_combined")) if prefixstr != "" else "inst_combined")
         theeval.streamDataFrame(rettab, filename, extension)
-        logging.info("combined instance data written to %s.%s" % (filename, extension))
+        logger.info("combined instance data written to %s.%s" % (filename, extension))
         # print the combined aggregated data if there are multiple filter groups present
         filename = "%s/%s" % (path, "_".join((prefixstr, "agg_combined")) if prefixstr != "" else "agg_combined")
         theeval.streamDataFrame(retagg, filename, extension)
-        logging.info("combined aggregated data written to %s.%s" % (filename, extension))
+        logger.info("combined aggregated data written to %s.%s" % (filename, extension))
 
     # print pd.concat([rettab, theeval.levelonedf], axis=1)
 

--- a/scripts/ipet-parse
+++ b/scripts/ipet-parse
@@ -94,7 +94,6 @@ argparser.add_argument("--docmode", action = "store_true", default = False, help
 
 if __name__ == '__main__':
 
-
     try:
         arguments = argparser.parse_args()
     except:
@@ -103,7 +102,7 @@ if __name__ == '__main__':
         exit()
     # if globals().get("help") is not None:
     logger = logging.getLogger()
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter('%(asctime)s - %(levelname)7s - %(name)s - %(message)s')
     ch = logging.StreamHandler(sys.stdout)
     ch.setFormatter(formatter)
     logger.addHandler(ch)
@@ -121,7 +120,7 @@ if __name__ == '__main__':
         logger.setLevel(logging.ERROR)
 
     if arguments.logfiles is None:
-        logging.info("No testruns specified, exiting")
+        logger.info("No testruns specified, exiting")
         sys.exit(0)
 
     # initialize an experiment
@@ -130,17 +129,17 @@ if __name__ == '__main__':
     for reader in loader.loadAdditionalReaders(arguments.readers):
 
         experiment.readermanager.registerReader(reader)
-        logging.info("Registered reader with name %s" % reader.getName())
+        logger.info("Registered reader with name %s" % reader.getName())
 
     for solver in loader.loadAdditionalSolvers():
         experiment.readermanager.addSolver(solver)
-        logging.info("Registered solver with name %s" % solver.getName())
+        logger.info("Registered solver with name %s" % solver.getName())
 
     for solufile in loader.loadAdditionalSolufiles(arguments.solufiles):
         experiment.addSoluFile(solufile)
-        logging.info("Imported solufile with name %s" % solufile)
+        logger.info("Imported solufile with name %s" % solufile)
 
-    logging.info("Start parsing process")
+    logger.info("Start parsing process")
 
     if type(arguments.logfiles) != io.TextIOWrapper:
         for logfile in arguments.logfiles:
@@ -154,9 +153,9 @@ if __name__ == '__main__':
                 filename = tr.filenames[0]
                 newfilename = "%s%s" % (os.path.splitext(filename)[0], TestRun.FILE_EXTENSION)
                 tr.saveToFile(newfilename)
-                logging.info("converted %s --> %s" % (filename, newfilename))
+                logger.info("converted %s --> %s" % (filename, newfilename))
             except:
-                logging.info("skipped testrun %s" % tr.getIdentification())
+                logger.info("skipped testrun %s" % tr.getIdentification())
     else:
         experiment.addStdinput()
         experiment.collectData()


### PR DESCRIPTION
Make the logger use the correct module names, use the logger instance instead of the logging class to print log output. 