### PR TITLE
save joineddata

### DIFF
--- a/ipet/Experiment.py
+++ b/ipet/Experiment.py
@@ -199,6 +199,7 @@ class Experiment:
 
         # post processing steps: things like primal integrals depend on several, independent data
         self.updateDatakeys()
+        self.joineddata = None
 
     def getDatakeys(self):
         return self.datakeymanager.getAllRepresentations()

--- a/ipet/Experiment.py
+++ b/ipet/Experiment.py
@@ -48,6 +48,7 @@ class Experiment:
 
         self.gaptol = gaptol
         self.validatedual = validatedual
+        self.joineddata = None
 
     def set_gaptol(self, gaptol : float):
         """
@@ -233,6 +234,9 @@ class Experiment:
 
         this may result in nonunique index, the data is simply concatenated
         """
+        if self.joineddata is not None:
+            return self.joineddata
+
         datalist = []
         for tr in self.getTestRuns():
             trdata = tr.data
@@ -243,7 +247,9 @@ class Experiment:
             datalist.append(trdata)
 
         # return pd.concat(datalist, sort=True).infer_objects() # in later pandas versions this needs a sort argument
-        return pd.concat(datalist).infer_objects()
+        self.joineddata = pd.concat(datalist).infer_objects()
+
+        return self.joineddata
 
     def calculateIntegrals(self):
         """ Calculate and store primal and dual integral values


### PR DESCRIPTION
inferring the datatypes takes a very long time, it makes sense to save the dataframe for occasions where the getJoinedDatee method is called twice (i.e. by rubberband)