### PR TITLE
use substring instead of split to parse metafile

### DIFF
--- a/ipet/parsing/StatisticReader.py
+++ b/ipet/parsing/StatisticReader.py
@@ -189,7 +189,7 @@ class MetaDataReader(StatisticReader):
         """
         if self.metadataexp.match(line):
 #            TODO better to allow more spaces?
-            [attr, datum] = line.split('@')[1].split()
+            [attr, datum] = line[1:].split()
             datum = datum.split('\n')[0]
             self.testrun.metadatadict[attr] = datum
 


### PR DESCRIPTION
I've metafiles where the datum can contain "@" - symbols.
Currently parsing the StatisticReader doesn't support that, instead the program exit with an error.

In the current program the line in the metafile is split at @. So if there is a second @ in the line, the following assumptions aren't fulfilled. 
-> Instead of splitting (which currently is only done for removing the @) I would use substring to remove the @ and then obtain the datum and the attribute. 

