### PR TITLE
make ipet-parse script multithreaded and add a tqdm progress bar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas==0.25.0
 pypandoc==1.4
 scipy==1.3.1
 toposort==1.5
+tqdm==4.56.0

--- a/scripts/ipet-parse
+++ b/scripts/ipet-parse
@@ -114,14 +114,15 @@ def setup_experiment(arguments, verbose=False):
 
     return experiment
 
-def process_one_outfile(task : tuple):
+def process_one_outfiles_group(task : tuple):
     # initialize an experiment
-    outfile, arguments = task
+    outfiles, arguments = task
     experiment = setup_experiment(arguments)
 
-    logger.info("Start parsing process of outfile '{}'".format(outfile))
+    logger.info("Start parsing process of outfile(s) {}".format(", ".join(outfiles)))
 
-    experiment.addOutputFile(outfile)
+    for o in outfiles:
+        experiment.addOutputFile(o)
 
     experiment.collectData()
 
@@ -144,7 +145,7 @@ def process_one_outfile(task : tuple):
             except:
                 logger.info("couldn't save data for testrun %s" % tr.getIdentification())
 
-    return outfile
+    return outfiles
 
 if __name__ == '__main__':
 
@@ -186,8 +187,15 @@ if __name__ == '__main__':
         pool = mp.Pool(nthreads)
         logger.info("Start parsing process using {} threads".format(nthreads))
 
-        tasks = [(outfile, arguments) for outfile in arguments.logfiles if outfile.endswith("out")]
-        for _ in tqdm.tqdm(pool.imap_unordered(process_one_outfile, tasks), total=len(tasks)):
+        # group the input files by their base names, to process related out and err files together
+        # META files are automatically picked up internally upon creation of a TestRun object
+        logfiles2basename = {}
+        for f in arguments.logfiles:
+            logfiles2basename.setdefault(os.path.splitext(f)[0], []).append(f)
+
+
+        tasks = [(outfiles, arguments) for outfiles in logfiles2basename.values()]
+        for _ in tqdm.tqdm(pool.imap_unordered(process_one_outfiles_group, tasks), total=len(tasks)):
             pass
 
         pool.close()

--- a/scripts/ipet-parse
+++ b/scripts/ipet-parse
@@ -92,6 +92,59 @@ argparser.add_argument("-v", "--validatedual", action = "store_true", default = 
 argparser.add_argument("-g", "--gaptol", type = float, default = Experiment.DEFAULT_GAPTOL, help = "relative tolerance for primal and dual objective validation")
 argparser.add_argument("--docmode", action = "store_true", default = False, help = "print this help as restructured text")
 argparser.add_argument("--csv", action = "store_true", default = False, help = "print the data as csv")
+argparser.add_argument("-j", "--jobs", default = -1, type=int, help = "number of threads to use (-1 for all available threads)")
+
+def setup_experiment(arguments, verbose=False):
+    experiment = Experiment(validatedual = arguments.validatedual, gaptol = arguments.gaptol)
+    for reader in loader.loadAdditionalReaders(arguments.readers):
+
+        experiment.readermanager.registerReader(reader)
+        if verbose:
+            logger.info("Registered reader with name %s" % reader.getName())
+
+    for solver in loader.loadAdditionalSolvers():
+        experiment.readermanager.addSolver(solver)
+        if verbose:
+            logger.info("Registered solver with name %s" % solver.getName())
+
+    for solufile in loader.loadAdditionalSolufiles(arguments.solufiles):
+        experiment.addSoluFile(solufile)
+        if verbose:
+            logger.info("Imported solufile with name %s" % solufile)
+
+    return experiment
+
+def process_one_outfile(task : tuple):
+    # initialize an experiment
+    outfile, arguments = task
+    experiment = setup_experiment(arguments)
+
+    logger.info("Start parsing process of outfile '{}'".format(outfile))
+
+    experiment.addOutputFile(outfile)
+
+    experiment.collectData()
+
+    # Write output
+    for tr in experiment.getTestRuns():
+        try:
+            filename = tr.filenames[0]
+            newfilename = "%s%s" % (os.path.splitext(filename)[0], TestRun.FILE_EXTENSION)
+            tr.saveToFile(newfilename)
+            logger.info("converted %s --> %s" % (filename, newfilename))
+        except:
+            logger.info("skipped testrun %s" % tr.getIdentification())
+
+        if arguments.csv:
+            try:
+                filename = tr.filenames[0]
+                newfilename = "%s%s" % (os.path.splitext(filename)[0], ".ipetdata.csv")
+                tr.saveToCSV(newfilename)
+                logger.info("saved data for %s --> %s" % (filename, newfilename))
+            except:
+                logger.info("couldn't save data for testrun %s" % tr.getIdentification())
+
+    return outfile
 
 if __name__ == '__main__':
 
@@ -120,52 +173,26 @@ if __name__ == '__main__':
     if type(arguments.logfiles) == io.TextIOWrapper and not arguments.debug:
         logger.setLevel(logging.ERROR)
 
-    if arguments.logfiles is None:
-        logger.info("No testruns specified, exiting")
-        sys.exit(0)
 
     # initialize an experiment
-    experiment = Experiment(validatedual = arguments.validatedual, gaptol = arguments.gaptol)
+    experiment = setup_experiment(arguments, verbose=True)
 
-    for reader in loader.loadAdditionalReaders(arguments.readers):
-
-        experiment.readermanager.registerReader(reader)
-        logger.info("Registered reader with name %s" % reader.getName())
-
-    for solver in loader.loadAdditionalSolvers():
-        experiment.readermanager.addSolver(solver)
-        logger.info("Registered solver with name %s" % solver.getName())
-
-    for solufile in loader.loadAdditionalSolufiles(arguments.solufiles):
-        experiment.addSoluFile(solufile)
-        logger.info("Imported solufile with name %s" % solufile)
-
-    logger.info("Start parsing process")
 
     if type(arguments.logfiles) != io.TextIOWrapper:
-        for logfile in arguments.logfiles:
-            experiment.addOutputFile(logfile)
+        import multiprocessing as mp
+        import tqdm
 
-        experiment.collectData()
+        nthreads = mp.cpu_count() if arguments.jobs == -1 else arguments.jobs
+        pool = mp.Pool(nthreads)
+        logger.info("Start parsing process using {} threads".format(nthreads))
 
-        # Write output
-        for tr in experiment.getTestRuns():
-            try:
-                filename = tr.filenames[0]
-                newfilename = "%s%s" % (os.path.splitext(filename)[0], TestRun.FILE_EXTENSION)
-                tr.saveToFile(newfilename)
-                logger.info("converted %s --> %s" % (filename, newfilename))
-            except:
-                logger.info("skipped testrun %s" % tr.getIdentification())
+        tasks = [(outfile, arguments) for outfile in arguments.logfiles if outfile.endswith("out")]
+        for _ in tqdm.tqdm(pool.imap_unordered(process_one_outfile, tasks), total=len(tasks)):
+            pass
 
-            if arguments.csv:
-                try:
-                    filename = tr.filenames[0]
-                    newfilename = "%s%s" % (os.path.splitext(filename)[0], ".ipetdata.csv")
-                    tr.saveToCSV(newfilename)
-                    logger.info("saved data for %s --> %s" % (filename, newfilename))
-                except:
-                    logger.info("couldn't save data for testrun %s" % tr.getIdentification())
+        pool.close()
+        pool.join()
+
     else:
         experiment.addStdinput()
         experiment.collectData()


### PR DESCRIPTION
what the description says. I parallelized this script for two reasons:

1. It is much faster (n times faster than before)
2. It consumes less memory than the previous variant, because an experiment and the contained TestRun object is freed immediately after it was parsed and stored to disk, instead of continuing to parse until all files were processed.

Drawback: Files such as meta data, error files etc. are simply discarded if passed to the script. However, I believe this is the same behavior as before. In order to associate a test run with an OUT file and completely differently named ERR/META/whatever file, one would need to setup a custom TestRun object writing custom Python code.

Check out the progress bar.