### PR TITLE
parsing primal heuristics stats of SCIP

### DIFF
--- a/ipet/parsing/Solver.py
+++ b/ipet/parsing/Solver.py
@@ -439,7 +439,7 @@ class SCIPSolver(Solver):
     shorttablecheckexp = re.compile('s\|')
     firstsolexp = re.compile('^  First Solution   :')
 
-    primalHeuristicsStatsArePrinted = False
+    primal_heuristics_stats_are_printed = False
 
     # variables needed for dual bound history
     regular_exp = re.compile('\|')  # compile the regular expression to speed up reader
@@ -571,21 +571,21 @@ class SCIPSolver(Solver):
 
     def extractPrimalHeuristics(self, line: str):
         if line.startswith('Primal Heuristics'):
-            self.primalHeuristicsStatsArePrinted = True
+            self.primal_heuristics_stats_are_printed = True
         elif not line.startswith(' '):
-            self.primalHeuristicsStatsArePrinted = False
-        elif self.primalHeuristicsStatsArePrinted:
+            self.primal_heuristics_stats_are_printed = False
+        elif self.primal_heuristics_stats_are_printed:
             name = re.compile("(\s+)(\w+\s?\w+)(\s*)").match(line).groups()[1]
-            execTimeExpr = re.compile("\s+\w+\s?\w+\s*:\s+(\S+)")
-            setupTimeExpr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+(\S+)")
-            callsExpr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+\d+.\d+\s+(\S+)")
-            foundExpr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+\d+.\d+\s+\d+\s+(\S+)")
-            bestExpr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+\d+.\d+\s+\d+\s+\d+\s+(\S+)")
-            self.extractByExpression(line, execTimeExpr, name + "_EXECTIME")
-            self.extractByExpression(line, setupTimeExpr, name + "_SETUPTIME")
-            self.extractByExpression(line, callsExpr, name + "_CALLS")
-            self.extractByExpression(line, foundExpr, name + "_FOUND")
-            self.extractByExpression(line, bestExpr, name + "_BEST")
+            exec_time_expr = re.compile("\s+\w+\s?\w+\s*:\s+(\S+)")
+            setup_time_expr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+(\S+)")
+            calls_expr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+\d+.\d+\s+(\S+)")
+            found_expr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+\d+.\d+\s+\d+\s+(\S+)")
+            best_expr = re.compile("\s+\w+\s?\w+\s*:\s+\d+.\d+\s+\d+.\d+\s+\d+\s+\d+\s+(\S+)")
+            self.extractByExpression(line, exec_time_expr, name + "Exectime")
+            self.extractByExpression(line, setup_time_expr, name + "Setuptime")
+            self.extractByExpression(line, calls_expr, name + "Calls")
+            self.extractByExpression(line, found_expr, name + "Found")
+            self.extractByExpression(line, best_expr, name + "Best")
 
 
 class FiberSCIPSolver(SCIPSolver):


### PR DESCRIPTION
hi Grergor, hi Franzi,

I would like to use IPET to evaluate how many (best) solutions a my new primal finds and how long is the execution time.
For that I extended the SCIP Solver so that these information are parsed. To the best of my knowledge the SCIP Solver doesn't parse this.

If the keyword `Primal Heuristics` appears, then the next lines will contain information bout primal heuristics, till a new headline (a.k.a. no space at the beginning) appears. Therefore all lines in between contain primal heuristics and the information name, execution time, setup time, calls, found, best will be parsed for every line/primal heuristics. 
The names of primal heurisitics may contain a space therefore the regex may contain an optional space.

hope this finds your approval :-)

Kind regards 
Alex

@GregorCH could you please add me to the IPET repro as contributor so I don't have to fork the repro every time. Unfortunately @fschloesser doesn't have the corresponding rights to do so.